### PR TITLE
Fixing typo

### DIFF
--- a/HVM/hvm_03_list.hvm
+++ b/HVM/hvm_03_list.hvm
@@ -28,7 +28,7 @@
 // Returns the last element of a list
 // (Last xs)
 
-// Returns the list without its first element
+// Returns the list without its last element
 // (Init xs)
 
 // Returns the length of the list


### PR DESCRIPTION
`Init` definition was wrong